### PR TITLE
fix(java): Omit IT prefix from test that uses mocks 

### DIFF
--- a/src/test/java/com/google/cloud/pubsublite/flink/SourceAndSinkTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/flink/SourceAndSinkTest.java
@@ -67,7 +67,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class ITSourceAndSinkTest {
+public class SourceAndSinkTest {
   // Callers must set GCLOUD_PROJECT
   private static final ProjectId PROJECT = ProjectId.of(System.getenv("GCLOUD_PROJECT"));
   private static final CloudZone ZONE = CloudZone.parse("us-central1-b");


### PR DESCRIPTION
Renaming this test name to prevent it from being categorized as an integration test. 

Currently, the use of `Mockito` causes problems when using native image testing (run `mvn test -P native` locally). Ideally we want to only include integration tests and unit tests in generated libraries for native image testing since they don't use Mockito. We filter on [the presence of these test naming conventions](https://github.com/googleapis/java-shared-config/blob/e4c3baa46d80cedf50cd937b301c399f14b3ff86/pom.xml#L809). Renaming this test will allow us to skip it for native image testing. 


