### PR TITLE
deps: use latest google-cloud-pubsublite-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,15 @@
       <version>2.0.6</version>
     </dependency>
     <dependency>
+      <groupId>com.google.flogger</groupId>
+      <artifactId>flogger</artifactId>
+      <version>0.8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-core</artifactId>
       <version>${flink.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,19 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>com.google.flogger:google-extensions</ignoredUnusedDeclaredDependency>
+            </ignoredUnusedDeclaredDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <dependencies>
     <dependency>
@@ -96,11 +109,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.flogger</groupId>
-      <artifactId>flogger</artifactId>
-      <version>0.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pubsublite-parent</artifactId>
-    <version>1.12.0</version>
+    <version>1.15.9</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>


### PR DESCRIPTION
The latest google-cloud-pubsublite-parent has the shared config parent that has the profile to disable nexus-staging-maven-plugin. This is needed to use new Central Portal API.

I confirmed:

```
suztomo@suztomo2:~/java-pubsublite-flink$ mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer
```
